### PR TITLE
feat: support operations as query string params

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -115,7 +115,8 @@ var (
 	ETagEnabled bool
 	ETagBuster  string
 
-	BaseURL string
+	BaseURL         string
+	QueryStringOpts bool
 
 	WhitelistProcessingOpts []string
 	Presets                 []string
@@ -284,6 +285,7 @@ func Reset() {
 	ETagBuster = ""
 
 	BaseURL = ""
+	QueryStringOpts = false
 
 	WhitelistProcessingOpts = make([]string, 0)
 	Presets = make([]string, 0)
@@ -459,6 +461,7 @@ func Configure() error {
 	configurators.String(&ETagBuster, "IMGPROXY_ETAG_BUSTER")
 
 	configurators.String(&BaseURL, "IMGPROXY_BASE_URL")
+	configurators.Bool(&QueryStringOpts, "IMGPROXY_QUERY_OPTS")
 
 	configurators.StringSlice(&WhitelistProcessingOpts, "IMGPROXY_WHITELIST_PROCESSING_OPTS")
 	configurators.StringSlice(&Presets, "IMGPROXY_PRESETS")

--- a/options/processing_options.go
+++ b/options/processing_options.go
@@ -949,7 +949,7 @@ func applyURLOptions(po *ProcessingOptions, options urlOptions) error {
 		if !isWhitelistedOption(opt) {
 			continue
 		}
-		
+
 		if err := applyURLOption(po, opt.Name, opt.Args); err != nil {
 			return err
 		}
@@ -1079,6 +1079,10 @@ func ParsePath(path string, headers http.Header) (*ProcessingOptions, string, er
 		return nil, "", ierrors.New(404, fmt.Sprintf("Invalid path: %s", path), "Invalid URL")
 	}
 
+	if queryStart := strings.IndexByte(path, '?'); queryStart >= 0 {
+		path = path[:queryStart]
+	}
+
 	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
 
 	var (
@@ -1098,4 +1102,12 @@ func ParsePath(path string, headers http.Header) (*ProcessingOptions, string, er
 	}
 
 	return po, imageURL, nil
+}
+
+func Parse(path string, header http.Header) (*ProcessingOptions, string, error) {
+	if config.QueryStringOpts {
+		return ParseQuery(path, header)
+	}
+
+	return ParsePath(path, header)
 }

--- a/options/query_options.go
+++ b/options/query_options.go
@@ -1,0 +1,68 @@
+package options
+
+import (
+	"fmt"
+	"github.com/imgproxy/imgproxy/v3/ierrors"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+func ParseQuery(path string, headers http.Header) (*ProcessingOptions, string, error) {
+	if path == "" || path == "/" {
+		return nil, "", ierrors.New(404, fmt.Sprintf("Invalid path: %s", path), "Invalid URL")
+	}
+
+	parsedUrl, err := url.ParseRequestURI(path)
+
+	if queryStart := strings.IndexByte(path, '?'); queryStart >= 0 {
+		path = path[:queryStart]
+	}
+
+	if err != nil {
+		return nil, "", ierrors.New(404, fmt.Sprintf("Invalid Query: %s", path), "Invalid Query")
+	}
+
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+
+	return parseQueryOptions(parts, parsedUrl.Query(), headers)
+}
+
+func parseQueryOptions(pathParts []string, ops url.Values, headers http.Header) (*ProcessingOptions, string, error) {
+
+	po, err := defaultProcessingOptions(headers)
+	if err != nil {
+		return nil, "", err
+	}
+
+	options := parseQueryToURLOptions(ops)
+
+	if err = applyURLOptions(po, options); err != nil {
+		return nil, "", err
+	}
+
+	url, extension, err := DecodeURL(pathParts)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if len(extension) > 0 {
+		if err = applyFormatOption(po, []string{extension}); err != nil {
+			return nil, "", err
+		}
+	}
+
+	return po, url, nil
+}
+
+func parseQueryToURLOptions(opts url.Values) urlOptions {
+	parsed := make(urlOptions, 0, len(opts))
+
+	for i, opt := range opts {
+		args := strings.Split(opt[len(opt)-1], ":")
+
+		parsed = append(parsed, urlOption{Name: i, Args: args})
+	}
+
+	return parsed
+}

--- a/options/query_options_test.go
+++ b/options/query_options_test.go
@@ -1,0 +1,292 @@
+package options
+
+import (
+	"encoding/base64"
+	"fmt"
+	"github.com/imgproxy/imgproxy/v3/config"
+	"github.com/imgproxy/imgproxy/v3/imagetype"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+type QueryProcessingOptionsTestSuite struct{ suite.Suite }
+
+func (s *QueryProcessingOptionsTestSuite) SetupTest() {
+	config.Reset()
+	config.QueryStringOpts = true
+	// Reset presets
+	presets = make(map[string]urlOptions)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParseBase64URL() {
+	originURL := "http://images.dev/lorem/ipsum.jpg?param=value"
+	path := fmt.Sprintf("/%s.png?size=100:100", base64.RawURLEncoding.EncodeToString([]byte(originURL)))
+	po, imageURL, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+	require.Equal(s.T(), originURL, imageURL)
+	require.Equal(s.T(), imagetype.PNG, po.Format)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParseBase64URLWithoutExtension() {
+	originURL := "http://images.dev/lorem/ipsum.jpg?param=value"
+	path := fmt.Sprintf("/%s?size=100:100", base64.RawURLEncoding.EncodeToString([]byte(originURL)))
+	po, imageURL, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+	require.Equal(s.T(), originURL, imageURL)
+	require.Equal(s.T(), imagetype.Unknown, po.Format)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParseBase64URLWithBase() {
+	config.BaseURL = "http://images.dev/"
+
+	originURL := "lorem/ipsum.jpg?param=value"
+	path := fmt.Sprintf("/%s.png?size=100:100", base64.RawURLEncoding.EncodeToString([]byte(originURL)))
+	po, imageURL, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+	require.Equal(s.T(), fmt.Sprintf("%s%s", config.BaseURL, originURL), imageURL)
+	require.Equal(s.T(), imagetype.PNG, po.Format)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParsePlainURL() {
+	originURL := "http://images.dev/lorem/ipsum.jpg"
+	path := fmt.Sprintf("/plain/%s@png?size=100:100", originURL)
+	po, imageURL, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+	require.Equal(s.T(), originURL, imageURL)
+	require.Equal(s.T(), imagetype.PNG, po.Format)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParsePlainURLWithoutExtension() {
+	originURL := "http://images.dev/lorem/ipsum.jpg"
+	path := fmt.Sprintf("/plain/%s?size=100:100", originURL)
+
+	po, imageURL, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+	require.Equal(s.T(), originURL, imageURL)
+	require.Equal(s.T(), imagetype.Unknown, po.Format)
+}
+func (s *QueryProcessingOptionsTestSuite) TestParsePlainURLEscaped() {
+	originURL := "http://images.dev/lorem/ipsum.jpg?param=value"
+	path := fmt.Sprintf("/plain/%s@png?size=100:100", url.PathEscape(originURL))
+	po, imageURL, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+	require.Equal(s.T(), originURL, imageURL)
+	require.Equal(s.T(), imagetype.PNG, po.Format)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParsePlainURLWithBase() {
+	config.BaseURL = "http://images.dev/"
+
+	originURL := "lorem/ipsum.jpg"
+	path := fmt.Sprintf("/plain/%s@png?size=100:100", originURL)
+	po, imageURL, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+	require.Equal(s.T(), fmt.Sprintf("%s%s", config.BaseURL, originURL), imageURL)
+	require.Equal(s.T(), imagetype.PNG, po.Format)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParsePlainURLEscapedWithBase() {
+	config.BaseURL = "http://images.dev/"
+
+	originURL := "lorem/ipsum.jpg?param=value"
+	path := fmt.Sprintf("/plain/%s@png?size=100:100", url.PathEscape(originURL))
+	po, imageURL, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+	require.Equal(s.T(), fmt.Sprintf("%s%s", config.BaseURL, originURL), imageURL)
+	require.Equal(s.T(), imagetype.PNG, po.Format)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParseQueryFormat() {
+	path := "/plain/http://images.dev/lorem/ipsum.jpg?format=webp"
+	po, _, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+
+	require.Equal(s.T(), imagetype.WEBP, po.Format)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParseQueryResize() {
+	path := "/plain/http://images.dev/lorem/ipsum.jpg?resize=fill:100:200:1"
+	po, _, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+
+	require.Equal(s.T(), ResizeFill, po.ResizingType)
+	require.Equal(s.T(), 100, po.Width)
+	require.Equal(s.T(), 200, po.Height)
+	require.True(s.T(), po.Enlarge)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParseQueryResizingType() {
+	path := "/plain/http://images.dev/lorem/ipsum.jpg?resizing_type=fill"
+	po, _, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+
+	require.Equal(s.T(), ResizeFill, po.ResizingType)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParseQuerySize() {
+	path := "/plain/http://images.dev/lorem/ipsum.jpg?size=100:200:1"
+	po, _, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+
+	require.Equal(s.T(), 100, po.Width)
+	require.Equal(s.T(), 200, po.Height)
+	require.True(s.T(), po.Enlarge)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParseQueryWidth() {
+	path := "/plain/http://images.dev/lorem/ipsum.jpg?width=100"
+	po, _, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+
+	require.Equal(s.T(), 100, po.Width)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParseQueryHeight() {
+	path := "/plain/http://images.dev/lorem/ipsum.jpg?height=100"
+	po, _, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+
+	require.Equal(s.T(), 100, po.Height)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParseQueryEnlarge() {
+	path := "/plain/http://images.dev/lorem/ipsum.jpg?enlarge=1"
+	po, _, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+
+	require.True(s.T(), po.Enlarge)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParseQueryExtend() {
+	path := "/plain/http://images.dev/lorem/ipsum.jpg?extend=1:so:10:20"
+	po, _, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+
+	require.Equal(s.T(), true, po.Extend.Enabled)
+	require.Equal(s.T(), GravitySouth, po.Extend.Gravity.Type)
+	require.Equal(s.T(), 10.0, po.Extend.Gravity.X)
+	require.Equal(s.T(), 20.0, po.Extend.Gravity.Y)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParseQueryGravity() {
+	path := "/plain/http://images.dev/lorem/ipsum.jpg?gravity=soea"
+	po, _, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+
+	require.Equal(s.T(), GravitySouthEast, po.Gravity.Type)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParseQueryGravityFocuspoint() {
+	path := "/plain/http://images.dev/lorem/ipsum.jpg?gravity=fp:0.5:0.75"
+	po, _, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+
+	require.Equal(s.T(), GravityFocusPoint, po.Gravity.Type)
+	require.Equal(s.T(), 0.5, po.Gravity.X)
+	require.Equal(s.T(), 0.75, po.Gravity.Y)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParseQueryQuality() {
+	path := "/plain/http://images.dev/lorem/ipsum.jpg?quality=55"
+	po, _, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+
+	require.Equal(s.T(), 55, po.Quality)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParseQueryBackground() {
+	path := "/plain/http://images.dev/lorem/ipsum.jpg?background=128:129:130"
+	po, _, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+
+	require.True(s.T(), po.Flatten)
+	require.Equal(s.T(), uint8(128), po.Background.R)
+	require.Equal(s.T(), uint8(129), po.Background.G)
+	require.Equal(s.T(), uint8(130), po.Background.B)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParseQueryBackgroundHex() {
+	path := "/plain/http://images.dev/lorem/ipsum.jpg?background=ffddee"
+	po, _, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+
+	require.True(s.T(), po.Flatten)
+	require.Equal(s.T(), uint8(0xff), po.Background.R)
+	require.Equal(s.T(), uint8(0xdd), po.Background.G)
+	require.Equal(s.T(), uint8(0xee), po.Background.B)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParseQueryBackgroundDisable() {
+	path := "/plain/http://images.dev/lorem/ipsum.jpg?background=fff&background="
+	po, _, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+
+	require.False(s.T(), po.Flatten)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParseQueryBlur() {
+	path := "/plain/http://images.dev/lorem/ipsum.jpg?blur=0.2"
+	po, _, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+
+	require.Equal(s.T(), float32(0.2), po.Blur)
+}
+
+func (s *QueryProcessingOptionsTestSuite) TestParseQuerySharpen() {
+	path := "/plain/http://images.dev/lorem/ipsum.jpg?sharpen=0.2"
+	po, _, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+
+	require.Equal(s.T(), float32(0.2), po.Sharpen)
+}
+func (s *QueryProcessingOptionsTestSuite) TestParseQueryDpr() {
+	path := "/plain/http://images.dev/lorem/ipsum.jpg?dpr=2"
+	po, _, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+
+	require.Equal(s.T(), 2.0, po.Dpr)
+}
+func (s *QueryProcessingOptionsTestSuite) TestParseQueryWatermark() {
+	path := "/plain/http://images.dev/lorem/ipsum.jpg?watermark=0.5:soea:10:20:0.6"
+	po, _, err := ParseQuery(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+
+	require.True(s.T(), po.Watermark.Enabled)
+	require.Equal(s.T(), GravitySouthEast, po.Watermark.Gravity.Type)
+	require.Equal(s.T(), 10.0, po.Watermark.Gravity.X)
+	require.Equal(s.T(), 20.0, po.Watermark.Gravity.Y)
+	require.Equal(s.T(), 0.6, po.Watermark.Scale)
+}
+
+func TestQueryProcessingOptions(t *testing.T) {
+	suite.Run(t, new(QueryProcessingOptionsTestSuite))
+}

--- a/processing_handler.go
+++ b/processing_handler.go
@@ -194,9 +194,6 @@ func handleProcessing(reqID string, rw http.ResponseWriter, r *http.Request) {
 	}
 
 	path := r.RequestURI
-	if queryStart := strings.IndexByte(path, '?'); queryStart >= 0 {
-		path = path[:queryStart]
-	}
 
 	if len(config.PathPrefix) > 0 {
 		path = strings.TrimPrefix(path, config.PathPrefix)
@@ -218,7 +215,7 @@ func handleProcessing(reqID string, rw http.ResponseWriter, r *http.Request) {
 		sendErrAndPanic(ctx, "security", ierrors.New(403, err.Error(), "Forbidden"))
 	}
 
-	po, imageURL, err := options.ParsePath(path, r.Header)
+	po, imageURL, err := options.Parse(path, r.Header)
 	checkErr(ctx, "path_parsing", err)
 
 	if !security.VerifySourceURL(imageURL) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Image processing options can only be specified using url paths

## What is the new behavior?

This PR introduce a toggle variable that allows to use processing options using query string values

## Additional context

Currently presets are not supported
