### PR TITLE
feat: crop max with and height

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -39,6 +39,8 @@ var (
 	MaxAnimationFrames int
 	MaxSvgCheckBytes   int
 	MaxRedirects       int
+	CropMaxWidth       int
+	CropMaxHeight      int
 
 	JpegProgressive       bool
 	PngInterlaced         bool
@@ -382,6 +384,9 @@ func Configure() error {
 	configurators.Int(&MaxAnimationFrames, "IMGPROXY_MAX_ANIMATION_FRAMES")
 
 	configurators.Int(&MaxRedirects, "IMGPROXY_MAX_REDIRECTS")
+
+	configurators.Int(&CropMaxWidth, "IMGPROXY_CROP_MAX_WIDTH")
+	configurators.Int(&CropMaxHeight, "IMGPROXY_CROP_MAX_HEIGHT")
 
 	configurators.Patterns(&AllowedSources, "IMGPROXY_ALLOWED_SOURCES")
 

--- a/processing/prepare.go
+++ b/processing/prepare.go
@@ -3,6 +3,7 @@ package processing
 import (
 	"math"
 
+	"github.com/imgproxy/imgproxy/v3/config"
 	"github.com/imgproxy/imgproxy/v3/imagedata"
 	"github.com/imgproxy/imgproxy/v3/imagetype"
 	"github.com/imgproxy/imgproxy/v3/imath"
@@ -45,6 +46,15 @@ func calcScale(width, height int, po *options.ProcessingOptions, imgtype imagety
 	var wshrink, hshrink float64
 
 	srcW, srcH := float64(width), float64(height)
+
+	if config.CropMaxWidth > 0 && srcW > float64(config.CropMaxWidth) {
+		po.Width = config.CropMaxWidth
+	}
+
+	if config.CropMaxHeight > 0 && srcH > float64(config.CropMaxHeight) {
+		po.Height = config.CropMaxHeight
+	}
+
 	dstW, dstH := float64(po.Width), float64(po.Height)
 
 	if po.Width == 0 {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Set a maximum limit in which the image can be resized using the optional environment variables `IMGPROXY_CROP_MAX_WIDTH`, `IMGPROXY_CROP_MAX_HEIGHT` 

Example:

Given an image of 4000x4000 when `IMGPROXY_CROP_MAX_WIDTH=2000` &  `IMGPROXY_CROP_MAX_HEIGHT=2000` are set

When resizing an image with the following parameters `w:1000` the maximum height will be `2000` instead of the original `4000`
