### PR TITLE
fix: pin release-notes-generator version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           semantic_version: 18
           extra_plugins: |
             @semantic-release/commit-analyzer
-            @semantic-release/release-notes-generator
+            @semantic-release/release-notes-generator@10.0.3
             @semantic-release/github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Version 20.0.0 of semantic-release and later is currently incompatible with cycjimmy/semantic-release-action, since it requires Node.js 18. GitHub does not provide this environment yet for JavaScript actions.

Version 10.0.3 of @semantic-release/release-notes-generator has a peer dependency of semantic-release v18